### PR TITLE
using local directory for toolchain

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -36,6 +36,5 @@ runs:
     - name: Link toolchain dir to predictable path in container
       run: |
         source=$(dirname $TOOLCHAIN_PATH)
-        mkdir -p $HOME/.local
-        ln -s $source $HOME/.local/${{ inputs.triple }}
+        ln -s $source ${{ github.workspace}}/${{ inputs.triple }}
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -36,5 +36,6 @@ runs:
     - name: Link toolchain dir to predictable path in container
       run: |
         source=$(dirname $TOOLCHAIN_PATH)
-        ln -s $source /opt/${{ inputs.triple }}
+        mkdir -p $HOME/.local
+        ln -s $source $HOME/.local/${{ inputs.triple }}
       shell: bash


### PR DESCRIPTION
Using only local $USER path for compiler installation, allowing workflows that are not containers (no sudo required)

Depends on outpost-os/meson-cross-files/pull/1